### PR TITLE
chore: update action runtime to node24

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set Node.js 20.x
-        uses: actions/setup-node@v3.6.0
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ outputs:
   new-mergeable-prs:
     description: 'List of all new mergeable PRs (json string)'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## What

Bump the action runtime from `node20` to `node24` in `action.yml`, and update the `check-dist` workflow to build on Node 24.x.

## Why

GitHub has [deprecated Node.js 20 for Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):

- Starting **2026-06-16**, JavaScript actions are forced to run on Node.js 24.
- On **2026-09-16**, Node.js 20 is removed from the runners.

Consumers of this action currently get this warning on every run:

> Node.js 20 actions are deprecated. ... `CodyTseng/auto-comment-merge-conflicts` ... Please check if updated versions of these actions are available that support Node.js 24.

This change silences the warning and keeps the action working past the deprecation dates. It mirrors the earlier `chore: update to node20` commit.

## Notes

- `dist/index.js` rebuilt on Node 24 (`npm run build && npm run package`) is **byte-identical**, so no bundle change is included in this PR.
- Tests pass on Node 24 (`npm test` → 25 passed, 5 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
